### PR TITLE
changed aiohttp's version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ telegraph[aio]
 markdown
 Flask==2.2.2
 gunicorn==20.1.0
-aiohttp==3.8.1
+aiohttp==3.8.2
 pymongo[srv]==3.12.3
 bs4
 heroku3


### PR DESCRIPTION
That version is known to have some issues with python 3.11. So use aiohttp==3.8.2 